### PR TITLE
Specify minSdk in AndroidManifest

### DIFF
--- a/cachewordlib/AndroidManifest.xml
+++ b/cachewordlib/AndroidManifest.xml
@@ -3,6 +3,9 @@
       package="info.guardianproject.cacheword"
       android:versionCode="1"
       android:versionName="1.0">
+    <uses-sdk
+        android:minSdkVersion="5"
+        android:targetSdkVersion="17" />
     <application android:label="@string/app_name" >
         <service android:name="info.guardianproject.cacheword.CacheWordService" android:enabled="true" android:exported="false" />
     </application>


### PR DESCRIPTION
prevents complaints about calls not available in SDK version 1.
