### PR TITLE
Fix PRNGFixes to work with SELinux enforce mode

### DIFF
--- a/cachewordlib/src/info/guardianproject/cacheword/PRNGFixes.java
+++ b/cachewordlib/src/info/guardianproject/cacheword/PRNGFixes.java
@@ -1,8 +1,5 @@
 package info.guardianproject.cacheword;
 
-import android.os.Build;
-import android.os.Process;
-
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -17,6 +14,10 @@ import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.SecureRandomSpi;
 import java.security.Security;
+
+import android.os.Build;
+import android.os.Process;
+import android.util.Log;
 
 /**
  * Fixes for the output of the default PRNG having low entropy.


### PR DESCRIPTION
makes /dev/urandom not writable on some devices

Based on update in:

http://android-developers.blogspot.com/2013/08/some-securerandom-thoughts.html
