### PR TITLE
mTimeoutIntent might be null and throw error, add if not null condition

### DIFF
--- a/cachewordlib/src/info/guardianproject/cacheword/CacheWordService.java
+++ b/cachewordlib/src/info/guardianproject/cacheword/CacheWordService.java
@@ -187,7 +187,9 @@ public class CacheWordService extends Service {
             Log.d(TAG, "disabled timeout alarm");
             if (mTimeoutIntent != null) {
                 AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
-                alarmManager.cancel(mTimeoutIntent);
+                if(mTimeoutIntent != null){
+                    alarmManager.cancel(mTimeoutIntent);
+                }
             }
         }
     }


### PR DESCRIPTION
 java.lang.NullPointerException: cancel() called with a null PendingIntent
                                                                      at android.app.AlarmManager.cancel(AlarmManager.java:890)
                                                                      at info.guardianproject.cacheword.CacheWordService.resetTimeout(CacheWordService.java:189)
                                                                      at info.guardianproject.cacheword.CacheWordService.attachSubscriber(CacheWordService.java:145)
                                                                      at info.guardianproject.cacheword.CacheWordHandler$2.onServiceConnected(CacheWordHandler.java:457)
                                                                      at android.app.LoadedApk$ServiceDispatcher.doConnected(LoadedApk.java:1465)
                                                                      at android.app.LoadedApk$ServiceDispatcher$RunConnection.run(LoadedApk.java:1482)
                                                                      at android.os.Handler.handleCallback(Handler.java:751)
                                                                      at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                      at android.os.Looper.loop(Looper.java:154)
                                                                      at android.app.ActivityThread.main(ActivityThread.java:6077)
                                                                      at java.lang.reflect.Method.invoke(Native Method)
                                                                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
                                                                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)